### PR TITLE
:bug: fix bug from issue #18

### DIFF
--- a/connector.py
+++ b/connector.py
@@ -51,7 +51,7 @@ class SOM1d(object):
         self.y_std = np.std(data[:, 1], axis=0)
 
         ratio = 4.0/3.0     # (Number of SOM unit) / (Number of points)
-        self.w = np.zeros(int(data.shape[0]*ratio), dtype=np.complex)
+        self.w = np.zeros(int(data.shape[0]*ratio), dtype=np.cdouble)
 
 
     @property

--- a/tuner.py
+++ b/tuner.py
@@ -30,7 +30,7 @@ class Tuner():
 
 
     def permute(self, index, order):
-        tests = np.empty((self.size, self.size), dtype=np.int)
+        tests = np.empty((self.size, self.size), dtype=np.int_)
         num = order[index]
         base = np.delete(order, index)
 


### PR DESCRIPTION
Hi 
I create this pull request for fix the bug mentioned by @taro8.
I change the np.complex (connector.py) by np.cdouble and np.int (tuner.py) by np.int_.
For those operation i respect the documentation bellow, [Numpy Documentation](https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations).

Note: need to be tested with a recent version of QGis > 3.30.3 or older

Kind regards,